### PR TITLE
fix PotcarData.get_potcars_from_structure and #125

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@
 *_BASE_*
 *_LOCAL_*
 *_REMOTE_*
+*__pycache__
 .coverage
 .tox
+.pytest_cache
 
 doc/build
 build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:  # copied from pgtest's travis.yml
     - sudo apt-get remove postgresql
     - sudo apt-get install postgresql
     - sudo updatedb
+    - pip install --upgrade pip
 install:
     - pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
     - pip install -e git+https://github.com/greschd/aiida_pytest#egg=aiida_pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - pip install --upgrade pip
     - pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
     - pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
-    - pip install -e git+https://github.com/greschd/aiida_pytest#egg=aiida_pytest
+      #- pip install -e git+https://github.com/greschd/aiida_pytest#egg=aiida_pytest
     - pip install -e .[regen_default_paws,graphs,dev]
     - pip install tox-travis
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ before_install:  # copied from pgtest's travis.yml
     - sudo apt-get remove postgresql
     - sudo apt-get install postgresql
     - sudo updatedb
-    - pip install --upgrade pip
 install:
+    - pip install --upgrade pip
+    - pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
     - pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
     - pip install -e git+https://github.com/greschd/aiida_pytest#egg=aiida_pytest
-    - pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
     - pip install -e .[regen_default_paws,graphs,dev]
     - pip install tox-travis
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-- PotcarData.get_potcars_from_structure() now returns an entry for each `kind.name` in the structure, not one per `kind.symbol`.
+- PotcarData.get_potcars_from_structure() now returns an entry for each `kind.name` in the structure, not one per `kind.symbol`
+- PotcarData.get_potcars_dict() no longer fails if there is more than one PotcarData with the same full name in the family
 
 ## [v0.2.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- PotcarData.get_potcars_from_structure() now returns an entry for each `kind.name` in the structure, not one per `kind.symbol`.
+
 ## [v0.2.3]
 
 ### Changed

--- a/aiida_vasp/data/potcar.py
+++ b/aiida_vasp/data/potcar.py
@@ -702,9 +702,9 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
         :raise MultipleObjectsError: if more than one UPF for the same element is found in the group.
         :raise NotExistent: if no UPF for an element in the group is found in the group.
         """
-        elements_to_name = {kind.symbol: kind.name for kind in structure.kinds}
-        return {(elements_to_name[element],): potcar
-                for element, potcar in cls.get_potcars_dict(elements_to_name.keys(), family_name, mapping=mapping).items()}
+        # elements_to_name = {kind.symbol: kind.name for kind in structure.kinds}
+        return {(kind_name,): potcar
+                for kind_name, potcar in cls.get_potcars_dict(structure.get_kind_names(), family_name, mapping=mapping).items()}
 
     @classmethod
     def _prepare_group_for_upload(cls, group_name, group_description=None, dry_run=False):

--- a/aiida_vasp/data/potcar.py
+++ b/aiida_vasp/data/potcar.py
@@ -691,11 +691,15 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
         """
         Given a POTCAR family name and a AiiDA structure, return a dictionary associating each kind name with its UpfData object.
 
+        :param structure: An AiiDA structure
+        :param family_name: The POTCAR family to be used
+        :param mapping: A mapping[kind name] -> ``full_name``
+
         The Dictionary looks as follows::
 
             {
-                (element1, ): PotcarData_for_kind1,
-                (element2, ): ...
+                (kind1.name, ): PotcarData_for_kind1,
+                (kind2.name, ): ...
             }
 
         This is to make the output of this function suitable for giving directly as input to VaspCalculation.process() instances.

--- a/aiida_vasp/data/potcar.py
+++ b/aiida_vasp/data/potcar.py
@@ -734,8 +734,8 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
             )
         """
         # elements_to_name = {kind.symbol: kind.name for kind in structure.kinds}
-        return {(kind_name,): potcar
-                for kind_name, potcar in cls.get_potcars_dict(structure.get_kind_names(), family_name, mapping=mapping).items()}
+        kind_names = structure.get_kind_names()
+        return {(kind_name,): potcar for kind_name, potcar in cls.get_potcars_dict(kind_names, family_name, mapping=mapping).items()}
 
     @classmethod
     def _prepare_group_for_upload(cls, group_name, group_description=None, dry_run=False):

--- a/aiida_vasp/data/potcar.py
+++ b/aiida_vasp/data/potcar.py
@@ -637,7 +637,7 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
 
         :param elements: The list of symbols to find POTCARs for
         :param family_name: The POTCAR family to be used
-        :param mapping: A mapping[element] -> ``full_name``
+        :param mapping: A mapping[element] -> ``full_name``, for example: mapping={'In': 'In', 'As': 'As_d'}
 
         If no POTCAR is found for a given element, a ``NotExistent`` error is raised.
 
@@ -693,7 +693,7 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
 
         :param structure: An AiiDA structure
         :param family_name: The POTCAR family to be used
-        :param mapping: A mapping[kind name] -> ``full_name``
+        :param mapping: A mapping[kind name] -> ``full_name``, for example: mapping={'In1': 'In', 'In2': 'In_d', 'As': 'As_d'}
 
         The Dictionary looks as follows::
 
@@ -706,6 +706,32 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
 
         :raise MultipleObjectsError: if more than one UPF for the same element is found in the group.
         :raise NotExistent: if no UPF for an element in the group is found in the group.
+
+
+        Example::
+
+            ## using VASP recommended POTCARs
+            from aiida_vasp.utils.default_paws import DEFAULT_LDA, DEFAULT_GW
+            vasp_process = CalculationFactory('vasp.vasp').process()
+            inputs = vasp_process.get_inputs_template()
+            inputs.structure = load_node(123)
+            inputs.potential = PotcarData.get_potcars_from_structure(
+                structure=inputs.structure,
+                family_name='PBE',
+                mapping=DEFAULT_GW
+            )
+
+            ## using custom POTCAR map
+            custom_mapping = {
+                'In1': 'In',
+                'In2': 'In_d',
+                'As': 'As_d'
+            }
+            inputs.potential = PotcarData.get_potcars_from_structure(
+                structure=inputs.structure,
+                family_name='PBE',
+                mapping=custom_mapping
+            )
         """
         # elements_to_name = {kind.symbol: kind.name for kind in structure.kinds}
         return {(kind_name,): potcar

--- a/aiida_vasp/data/tests/test_potcar.py
+++ b/aiida_vasp/data/tests/test_potcar.py
@@ -168,7 +168,7 @@ def test_potcar_from_structure(fresh_aiida_env, potcar_family):
     indium_2.append_atom(position=[0, 0, 0], symbols='In')
     indium_2.append_atom(position=[1, 0, 0], symbols='In', name='In1')
     in2_potcars = get_data_class('vasp.potcar').get_potcars_from_structure(indium_2, potcar_family, mapping={'In': 'In_d', 'In1': 'In_d'})
-    assert in2_potcars.keys() == [('In',), ('In1',)]
+    assert set(in2_potcars.keys()) == {('In',), ('In1',)}
     in_d_potcar = get_data_class('vasp.potcar').find(family_name=potcar_family, full_name='In_d')[0]
     assert in2_potcars[('In',)].uuid == in_d_potcar.uuid == in2_potcars[('In1',)].uuid
 

--- a/aiida_vasp/data/tests/test_potcar.py
+++ b/aiida_vasp/data/tests/test_potcar.py
@@ -166,9 +166,11 @@ def test_potcar_from_structure(fresh_aiida_env, potcar_family):
     """Test getting POTCARS from a family for a structure."""
     indium_2 = get_data_node('structure')
     indium_2.append_atom(position=[0, 0, 0], symbols='In')
-    indium_2.append_atom(position=[1, 0, 0], symbols='In')
-    in2_potcars = get_data_class('vasp.potcar').get_potcars_from_structure(indium_2, potcar_family, mapping={'In': 'In_d'})
-    assert [kind[0] for kind in in2_potcars.keys()] == ['In']
+    indium_2.append_atom(position=[1, 0, 0], symbols='In', name='In1')
+    in2_potcars = get_data_class('vasp.potcar').get_potcars_from_structure(indium_2, potcar_family, mapping={'In': 'In_d', 'In1': 'In_d'})
+    assert in2_potcars.keys() == [('In',), ('In1',)]
+    in_d_potcar = get_data_class('vasp.potcar').find(family_name=potcar_family, full_name='In_d')
+    assert in2_potcars[('In',)].uuid == in_d_potcar.uuid == in2_potcars[('In1',)]
 
 
 def test_upload(fresh_aiida_env, temp_pot_folder):

--- a/aiida_vasp/data/tests/test_potcar.py
+++ b/aiida_vasp/data/tests/test_potcar.py
@@ -169,8 +169,8 @@ def test_potcar_from_structure(fresh_aiida_env, potcar_family):
     indium_2.append_atom(position=[1, 0, 0], symbols='In', name='In1')
     in2_potcars = get_data_class('vasp.potcar').get_potcars_from_structure(indium_2, potcar_family, mapping={'In': 'In_d', 'In1': 'In_d'})
     assert in2_potcars.keys() == [('In',), ('In1',)]
-    in_d_potcar = get_data_class('vasp.potcar').find(family_name=potcar_family, full_name='In_d')
-    assert in2_potcars[('In',)].uuid == in_d_potcar.uuid == in2_potcars[('In1',)]
+    in_d_potcar = get_data_class('vasp.potcar').find(family_name=potcar_family, full_name='In_d')[0]
+    assert in2_potcars[('In',)].uuid == in_d_potcar.uuid == in2_potcars[('In1',)].uuid
 
 
 def test_upload(fresh_aiida_env, temp_pot_folder):

--- a/aiida_vasp/io/tests/test_outcar_io.py
+++ b/aiida_vasp/io/tests/test_outcar_io.py
@@ -17,3 +17,8 @@ def test_parse_outcar():
     result = params['parameters'].get_dict()
     assert result['volume'] == 65.94
     assert result['efermi'] == 7.2948
+    assert result['energies']
+    assert result['symmetries']['num_space_group_operations'] == 48
+    assert result['symmetries']['num_point_group_operations'] == 48
+    assert result['symmetries']['point_symmetry'] == 'O_h'
+    assert result['symmetries']['space_group'] == 'D_2d'

--- a/aiida_vasp/test_data/outcar/OUTCAR
+++ b/aiida_vasp/test_data/outcar/OUTCAR
@@ -130,6 +130,7 @@ Analysis of symmetry for initial positions (statically):
 
 
 The static configuration has the point symmetry O_h .
+ The point group associated with its full space group is D_2d.
 
 
 Analysis of symmetry for dynamics (positions and initial velocities):

--- a/ops/run_coveralls.py
+++ b/ops/run_coveralls.py
@@ -1,0 +1,21 @@
+"""Run coveralls only on travis."""
+import os
+import subprocess
+import click
+
+
+def echo_call(cmd):
+    click.echo('calling: {}'.format(' '.join(cmd)), err=True)
+
+
+@click.command()
+def main():
+    """Run coveralls only on travis."""
+    if os.getenv('TRAVIS'):
+        cmd = ['coveralls']
+        echo_call(cmd)
+        subprocess.call(cmd)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ pylint
 flake8
 yapf
 coverage
-git+https://github.com/greschd/aiida_pytest#egg=aiida_pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pylint
 flake8
 yapf
 coverage
+git+https://github.com/greschd/aiida_pytest#egg=aiida_pytest

--- a/setup.json
+++ b/setup.json
@@ -59,9 +59,6 @@
         "regen_default_paws": [
             "lxml"
         ], 
-        "test": [
-            "aiida-pytest"
-        ], 
         "wannier": [
             "aiida-wannier90"
         ]

--- a/tests_pytest/conftest.py
+++ b/tests_pytest/conftest.py
@@ -1,41 +1,42 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# yapf: disable
 """Test fixtures"""
 
 import json
 import operator
 
 import pytest
-from aiida_pytest import *  # pylint: disable=wildcard-import,unused-wildcard-import
-
-
-@pytest.fixture
-# pylint: disable=protected-access
-def test_name(request):
-    """Returns module_name.function_name for a given test"""
-    return request.module.__name__ + '/' + request._parent_request._pyfuncitem.name
-
-
-@pytest.fixture
-def compare_data(request, test_name, scope="session"):  # pylint: disable=unused-argument,redefined-outer-name
-    """
-    Returns a function which either saves some data to a file or (if that file exists already)
-
-    compares it to pre-existing data using a given comparison function.
-    """
-
-    def inner(compare_fct, data, tag=None):
-        full_name = test_name + (tag or '')
-        val = request.config.cache.get(full_name, None)
-        if val is None:
-            request.config.cache.set(full_name, json.loads(json.dumps(data)))
-            raise ValueError('Reference data does not exist.')
-        else:
-            assert compare_fct(val, json.loads(json.dumps(data)))  # get rid of json-specific quirks
-
-    return inner
-
-
-@pytest.fixture
-def compare_equal(compare_data):  # pylint: disable=redefined-outer-name
-    return lambda data, tag=None: compare_data(operator.eq, data, tag)
+# ~ from aiida_pytest import *  # pylint: disable=wildcard-import,unused-wildcard-import
+# ~
+# ~
+# ~ @pytest.fixture
+# ~ # pylint: disable=protected-access
+# ~ def test_name(request):
+# ~    """Returns module_name.function_name for a given test"""
+# ~    return request.module.__name__ + '/' + request._parent_request._pyfuncitem.name
+# ~
+# ~
+# ~ @pytest.fixture
+# ~ def compare_data(request, test_name, scope="session"):  # pylint: disable=unused-argument,redefined-outer-name
+# ~    """
+# ~    Returns a function which either saves some data to a file or (if that file exists already)
+# ~
+# ~    compares it to pre-existing data using a given comparison function.
+# ~    """
+# ~
+# ~    def inner(compare_fct, data, tag=None):
+# ~        full_name = test_name + (tag or '')
+# ~        val = request.config.cache.get(full_name, None)
+# ~        if val is None:
+# ~            request.config.cache.set(full_name, json.loads(json.dumps(data)))
+# ~            raise ValueError('Reference data does not exist.')
+# ~        else:
+# ~            assert compare_fct(val, json.loads(json.dumps(data)))  # get rid of json-specific quirks
+# ~
+# ~    return inner
+# ~
+# ~
+# ~ @pytest.fixture
+# ~ def compare_equal(compare_data):  # pylint: disable=redefined-outer-name
+# ~    return lambda data, tag=None: compare_data(operator.eq, data, tag)

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@ envlist = py27
 [testenv]
 passenv = TRAVIS TRAVIS_*
 deps = 
+    pip>=10
     .[regen_default_paws,graphs,dev]
+    git+https://github.com/aiidateam/aiida_core#egg=aiida-core
     git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
     git+https://github.com/greschd/aiida_pytest#egg=aiida_pytest
-    git+https://github.com/aiidateam/aiida_core#egg=aiida-core
     coveralls
 install_command = pip install {opts} {packages}
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,18 +3,19 @@ envlist = py27
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
+setenv = AIIDA_PATH={toxworkdir}/.aiida
+
 deps = 
     pip>=10
-    .[regen_default_paws,graphs,dev]
     git+https://github.com/aiidateam/aiida_core#egg=aiida-core
     git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
-    git+https://github.com/greschd/aiida_pytest#egg=aiida_pytest
+    .[regen_default_paws,graphs,dev]
     coveralls
 install_command = pip install {opts} {packages}
 
 commands = 
     pytest --cov-report=term-missing --cov={envsitepackagesdir}/aiida_vasp
-    coveralls
+    python {toxinidir}/ops/run_coveralls.py
 
 [flake8]
 max-line-length = 140


### PR DESCRIPTION
fixes #125

`get_potcars_from_structure` was looping over `kind.symbol`s, now correctly loops over `kind.name`s. This was stopping it from working correctly for structures with kind names differing from the kind symbols.