### PR TITLE
Test cli access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
     - pip install tox-travis coveralls
 env:
     - TEST_TYPE="pre-commit"
+    - TEST_TYPE="unittests" TOX_ENV=py27-aiida_11
     - TEST_TYPE="unittests" TOX_ENV=py27-aiida_stable
     - TEST_TYPE="unittests" TOX_ENV=py27-aiida_dev
 script: ./run_ci_tests.sh

--- a/aiida_vasp/commands/tests/test_potcar_cmd.py
+++ b/aiida_vasp/commands/tests/test_potcar_cmd.py
@@ -194,3 +194,9 @@ def test_exportfamilies(fresh_aiida_env, potcar_family, tmpdir):
     result = run_cmd('exportfamily', ['--dry-run', '--as-archive', '--name', potcar_family, '--path', str(new_arch)])
     assert not result.exception
     assert not new_arch.exists()
+
+
+def test_call_from_vasp():
+    import subprocess
+    output = subprocess.check_output(['verdi', 'data', 'potcar-vasp', '--help'])
+    assert 'Usage: verdi data vasp-potcar' in output

--- a/aiida_vasp/commands/tests/test_potcar_cmd.py
+++ b/aiida_vasp/commands/tests/test_potcar_cmd.py
@@ -5,12 +5,19 @@ import pytest
 from py import path as py_path  # pylint: disable=no-member,no-name-in-module
 from click.testing import CliRunner
 from monty.collections import AttrDict
+from packaging import version
+
+from aiida import __version__ as aiida_version
 
 from aiida_vasp.commands.potcar import potcar
 from aiida_vasp.utils.fixtures.testdata import data_path
 from aiida_vasp.utils.aiida_utils import get_data_class
 from aiida_vasp.utils.fixtures.environment import aiida_env, fresh_aiida_env
 from aiida_vasp.utils.fixtures.data import potcar_family, POTCAR_FAMILY_NAME, temp_pot_folder
+
+AIIDA_VERSION = version.parse(aiida_version)
+V_0_12_0 = version.parse('0.12.0')
+V_0_12_1 = version.parse('0.12.1')
 
 
 @pytest.fixture
@@ -196,7 +203,8 @@ def test_exportfamilies(fresh_aiida_env, potcar_family, tmpdir):
     assert not new_arch.exists()
 
 
+@pytest.mark.xfail(V_0_12_0 <= AIIDA_VERSION <= V_0_12_1, reason='Plugin commands broken in "aiida >= 0.12.0, <= 0.12.1"')
 def test_call_from_vasp():
     import subprocess
-    output = subprocess.check_output(['verdi', 'data', 'potcar-vasp', '--help'])
+    output = subprocess.check_output(['verdi', 'data', 'vasp-potcar', '--help'])
     assert 'Usage: verdi data vasp-potcar' in output

--- a/aiida_vasp/commands/tests/test_potcar_cmd.py
+++ b/aiida_vasp/commands/tests/test_potcar_cmd.py
@@ -203,7 +203,6 @@ def test_exportfamilies(fresh_aiida_env, potcar_family, tmpdir):
     assert not new_arch.exists()
 
 
-@pytest.mark.xfail(V_0_12_0 <= AIIDA_VERSION <= V_0_12_1, reason='Plugin commands broken in "aiida >= 0.12.0, <= 0.12.1"')
 def test_call_from_vasp():
     import subprocess
     output = subprocess.check_output(['verdi', 'data', 'vasp-potcar', '--help'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-aiida_{stable,dev}
+envlist = py27-aiida_{11,stable,dev}
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
@@ -7,6 +7,7 @@ setenv = AIIDA_PATH={toxworkdir}/.aiida
 
 deps = 
     pip>=10
+    aiida_11: aiida-core>=0.11.4,<0.12.0
     aiida_stable: aiida-core
     aiida_dev: git+https://github.com/aiidateam/aiida_core#egg=aiida-core
     git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
@@ -16,6 +17,7 @@ whitelist_externals =
                     rm
 
 commands = 
+    aiida_11: reentry scan -r aiida
     mkdir -p {toxworkdir}/.aiida
     pytest --cov-report=term-missing --cov-append --cov={envsitepackagesdir}/aiida_vasp
     rm -r {toxworkdir}/.aiida

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ whitelist_externals =
 
 commands = 
     aiida_11: reentry scan -r aiida
+    aiida_stable: reentry scan -r aiida
     mkdir -p {toxworkdir}/.aiida
     pytest --cov-report=term-missing --cov-append --cov={envsitepackagesdir}/aiida_vasp
     rm -r {toxworkdir}/.aiida


### PR DESCRIPTION
Add a test that calls `verdi data vasp-potcar` on the command line, to make sure it works.

Expand testing to cover aiida versions 0.11.4, current stable, `develop` branch. These tests are executed in parallel on travis