### PR TITLE
Added support for parsing 'alternatives' + clean up

### DIFF
--- a/aiida_vasp/io/parser.py
+++ b/aiida_vasp/io/parser.py
@@ -26,6 +26,8 @@ Usage::
                 'prerequisites: ['required_quantity'],  # This prohibits the parser from trying to parse item1 without ``required_quantity``
                 'alternatives': ['alternative_quantity1', ... ] # Optional. If a quantity can be parsed from more than
                 ## one file, a list of alternative quantities can be provided here.
+                'is_alternative': another_quantity # Optional. If this quantity is an alternative to another_quantity
+                ## set this flag. The VaspParser will automatically add this quantity to another_quantities alternatives.
             }
             'item2': {
                 'inputs': [],

--- a/aiida_vasp/io/parser.py
+++ b/aiida_vasp/io/parser.py
@@ -17,13 +17,15 @@ Usage::
     ExampleFileParser(BaseFileParser):
 
         PARSABLE_ITEMS = {
-            'item1': {
+            'item1': { # The name of a quantity. It should be unique among all of the FileParsers.
                 'inputs': ['required_quantity'],  # This quantity will be parsed first and made available in time if possible
                 'parsers': ['ExampleFile'], # During setup the VaspParser will check, whether ExampleFile has been retrieved
                 ## and initialise the corresponding parser, if this quantity is requested by setting any of the
                 ## 'parser_settings['add_OutputNode'] = True'
                 'nodeName': ['examples'],  # The quantity will be added to the 'output_examples' output node
                 'prerequisites: ['required_quantity'],  # This prohibits the parser from trying to parse item1 without ``required_quantity``
+                'alternatives': ['alternative_quantity1', ... ] # Optional. If a quantity can be parsed from more than
+                ## one file, a list of alternative quantities can be provided here.
             }
             'item2': {
                 'inputs': [],

--- a/aiida_vasp/parsers/file_parser_definitions.py
+++ b/aiida_vasp/parsers/file_parser_definitions.py
@@ -1,0 +1,61 @@
+"""Module defining sets of FileParsers to be used by the VaspParser"""
+
+from aiida_vasp.io.doscar import DosParser
+from aiida_vasp.io.eigenval import EigParser
+from aiida_vasp.io.kpoints import KpParser
+from aiida_vasp.io.outcar import OutcarParser
+from aiida_vasp.io.vasprun import VasprunParser
+from aiida_vasp.io.chgcar import ChgcarParser
+from aiida_vasp.io.wavecar import WavecarParser
+from aiida_vasp.io.poscar import PoscarParser
+
+FILE_PARSER_SETS = {
+    'default': {
+        'DOSCAR': {
+            'parser_class': DosParser,
+            'is_critical': False,
+            'status': 'Unknown'
+        },
+        'EIGENVAL': {
+            'parser_class': EigParser,
+            'is_critical': False,
+            'status': 'Unknown'
+        },
+        'IBZKPT': {
+            'parser_class': KpParser,
+            'is_critical': False,
+            'status': 'Unknown'
+        },
+        'OUTCAR': {
+            'parser_class': OutcarParser,
+            'is_critical': True,
+            'status': 'Unknown'
+        },
+        'vasprun.xml': {
+            'parser_class': VasprunParser,
+            'is_critical': True,
+            'status': 'Unknown'
+        },
+        'CHGCAR': {
+            'parser_class': ChgcarParser,
+            'is_critical': False,
+            'status': 'Unknown'
+        },
+        'WAVECAR': {
+            'parser_class': WavecarParser,
+            'is_critical': False,
+            'status': 'Unknown'
+        },
+        'CONTCAR': {
+            'parser_class': PoscarParser,
+            'is_critical': False,
+            'status': 'Unknown'
+        },
+    },
+}
+
+
+def get_file_parser_set(parser_set):
+    if parser_set in FILE_PARSER_SETS:
+        return FILE_PARSER_SETS[parser_set]
+    return FILE_PARSER_SETS['default']

--- a/aiida_vasp/parsers/file_parser_definitions.py
+++ b/aiida_vasp/parsers/file_parser_definitions.py
@@ -55,7 +55,7 @@ FILE_PARSER_SETS = {
 }
 
 
-def get_file_parser_set(parser_set):
-    if parser_set in FILE_PARSER_SETS:
-        return FILE_PARSER_SETS[parser_set]
-    return FILE_PARSER_SETS['default']
+def get_file_parser_set(parser_set='default'):
+    if parser_set not in FILE_PARSER_SETS:
+        return None
+    return FILE_PARSER_SETS[parser_set]

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -9,7 +9,8 @@ from aiida_vasp.utils.fixtures import *
 from aiida_vasp.utils.fixtures.calcs import ONLY_ONE_CALC
 
 
-class TestFileParser(object):
+class ExampleFileParser(BaseFileParser):
+    """Example FileParser class for testing VaspParsers functionality."""
 
     PARSABLE_ITEMS = {
         'quantity_with_alternatives': {
@@ -40,6 +41,12 @@ class TestFileParser(object):
         },
     }
 
+    def _parse_file(self, inputs):
+        result = {}
+        for quantity in ExampleFileParser.PARSABLE_ITEMS:
+            result[quantity] = None
+        return result
+
 
 @pytest.fixture
 def vasp_parser_with_test(vasp_nscf_and_ref, ref_retrieved_nscf):
@@ -48,7 +55,7 @@ def vasp_parser_with_test(vasp_nscf_and_ref, ref_retrieved_nscf):
     vasp_calc, _ = vasp_nscf_and_ref
     vasp_calc.use_settings(ParameterData(dict={'parser_settings': {'add_quantity_with_alternatives': True, 'add_quantity2': True}}))
     parser = vasp_calc.get_parserclass()(vasp_calc)
-    parser.add_file_parser('test_parser', {'parser_class': TestFileParser, 'is_critical': False})
+    parser.add_file_parser('test_parser', {'parser_class': ExampleFileParser, 'is_critical': False})
     success, outputs = parser.parse_with_retrieved({'retrieved': ref_retrieved_nscf})
     return parser
 
@@ -58,13 +65,12 @@ def test_parsable_quantities(vasp_parser_with_test):
     """Check whether parsable quantities are set as intended."""
     parser = vasp_parser_with_test
     parsable_quantities = parser._parsable_quantities
-    for quantity in TestFileParser.PARSABLE_ITEMS:
+    for quantity in ExampleFileParser.PARSABLE_ITEMS:
         assert quantity in parsable_quantities
 
-    print parsable_quantities['quantity1']
-    assert parsable_quantities['quantity1'].have_files
+    assert parsable_quantities['quantity1'].has_files
     assert parsable_quantities['quantity1'].is_parsable
-    assert not parsable_quantities['quantity_with_alternatives'].have_files
+    assert not parsable_quantities['quantity_with_alternatives'].has_files
     assert parsable_quantities['quantity2'].is_parsable
     assert not parsable_quantities['quantity3'].is_parsable
     assert 'non_existing_quantity' in parsable_quantities

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -1,0 +1,83 @@
+"""Unittests for VaspParser"""
+# pylint: disable=unused-import,redefined-outer-name,unused-argument,unused-wildcard-import,wildcard-import
+# pylint: disable=protected-access,unused-variable,too-few-public-methods
+
+import pytest
+
+from aiida_vasp.io.parser import BaseFileParser
+from aiida_vasp.utils.fixtures import *
+from aiida_vasp.utils.fixtures.calcs import ONLY_ONE_CALC
+
+
+class TestFileParser(object):
+
+    PARSABLE_ITEMS = {
+        'quantity_with_alternatives': {
+            'inputs': [],
+            'parsers': ['DUMMY'],
+            'nodeName': 'structure',
+            'prerequisites': [],
+        },
+        'quantity1': {
+            'inputs': [],
+            'parsers': ['CONTCAR'],
+            'nodeName': '',
+            'is_alternative': 'quantity_with_alternatives',
+            'prerequisites': []
+        },
+        'quantity2': {
+            'inputs': [],
+            'parsers': ['CONTCAR'],
+            'nodeName': '',
+            'prerequisites': ['quantity1']
+        },
+        'quantity3': {
+            'inputs': [],
+            'parsers': ['CONTCAR'],
+            'nodeName': '',
+            'is_alternative': 'non_existing_quantity',
+            'prerequisites': ['quantity_with_alternatives']
+        },
+    }
+
+
+@pytest.fixture
+def vasp_parser_with_test(vasp_nscf_and_ref, ref_retrieved_nscf):
+    """Fixture providing a VaspParser instance coupled to a VaspCalculation."""
+    from aiida.orm.data.parameter import ParameterData
+    vasp_calc, _ = vasp_nscf_and_ref
+    vasp_calc.use_settings(ParameterData(dict={'parser_settings': {'add_quantity_with_alternatives': True, 'add_quantity2': True}}))
+    parser = vasp_calc.get_parserclass()(vasp_calc)
+    parser.add_file_parser('test_parser', {'parser_class': TestFileParser, 'is_critical': False})
+    success, outputs = parser.parse_with_retrieved({'retrieved': ref_retrieved_nscf})
+    return parser
+
+
+@ONLY_ONE_CALC
+def test_parsable_quantities(vasp_parser_with_test):
+    """Check whether parsable quantities are set as intended."""
+    parser = vasp_parser_with_test
+    parsable_quantities = parser._parsable_quantities
+    for quantity in TestFileParser.PARSABLE_ITEMS:
+        assert quantity in parsable_quantities
+
+    print parsable_quantities['quantity1']
+    assert parsable_quantities['quantity1'].have_files
+    assert parsable_quantities['quantity1'].is_parsable
+    assert not parsable_quantities['quantity_with_alternatives'].have_files
+    assert parsable_quantities['quantity2'].is_parsable
+    assert not parsable_quantities['quantity3'].is_parsable
+    assert 'non_existing_quantity' in parsable_quantities
+
+
+@ONLY_ONE_CALC
+def test_quantities_to_parse(vasp_parser_with_test):
+    """Check if quantities are added to quantities to parse correctly."""
+    parser = vasp_parser_with_test
+    quantities_to_parse = parser._quantities_to_parse
+    # after parse_with_retrieved quantities_to_parse will be empty, so we
+    # have to set it one more time.
+    parser._check_and_validate_settings()
+    assert 'quantity2' in quantities_to_parse
+    assert 'quantity_with_alternatives' not in quantities_to_parse
+    assert 'quantity1' in quantities_to_parse

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -225,9 +225,9 @@ class VaspParser(BaseParser):
                 continue
             quantity = key[4:]
             if quantity not in self._parsable_quantities:
-                self.logger.warning(
-                    '{0} has been requested by setting add_{0}'.format(quantity) +
-                    ' however it has not been implemented. Please check the docstrings' + ' in aiida_vasp.parsers.vasp.py for valid input.')
+                self.logger.warning('{0} has been requested by setting add_{0}'.format(quantity) +
+                                    ' however it has not been implemented. Please check the docstrings' +
+                                    ' in aiida_vasp.parsers.vasp.py for valid input.')
                 continue
 
             # Found a node, which should be added, add itself and all it's perequisites to the quantities to parse.

--- a/aiida_vasp/utils/extended_dicts.py
+++ b/aiida_vasp/utils/extended_dicts.py
@@ -1,0 +1,42 @@
+"""Extensions of Pythons standard dict as well as Aiida's extendedDicts."""
+
+from aiida.common.extendeddicts import AttributeDict
+
+
+class DictWithAttributes(AttributeDict):
+    """
+    Extension of the AttributeDict from Aiida.common.
+
+    This class internally stores values in a dictionary, but exposes
+    the keys also as attributes, i.e. asking for attrdict.key
+    will return the value of attrdict['key'] and so on.
+
+    If the key is not in the dict a default value will be returned. Every
+    key, that is not defined in _DEFAULT_VALUES, will simply return None.
+    """
+
+    def __init__(self, init=None, defaults=None):
+        """
+        Possibly set the initial values of the dictionary from an external dictionary init.
+
+        Note that the attribute-calling syntax will work only 1 level deep.
+        """
+        super(DictWithAttributes, self).__init__(init)
+        if defaults is None:
+            defaults = {}
+        self._default_values = defaults
+
+    def __getattr__(self, attr):
+        """Read a key as an attribute. Return a Default value on missing key."""
+        return self.get(attr)
+
+    def __setattr__(self, attr, value):
+        """Set a key as an attribute."""
+        self[attr] = value
+
+    def get(self, attr):
+        default = self['_default_values'].get(attr, None)
+        if attr in self:
+            return self[attr]
+
+        return default


### PR DESCRIPTION
Quantities can now have 'alternatives', which will be parsed, if the main quantity can not be parsed, due to missing files. The 'alternativees' can be set as an optional card in the dictionary defining the original quantity. This should take care of the issue of priority of files from which a quantity should be parsed in case, that it can be parsed from more than one. The general policy here should be that quantity names are unique.

For this reason the 'quantities' have been promoted to objects inside of the VaspParser, which can be initialised based on the dictionary provided in the FileParsers. This should keep adding new quantities to the FileParsers relatively simple.  

In addition this allowed for a bit of cleanup in the VaspParser, because I could now get rid of all of the 'should_parse_file' variables, because a quantity will now have information about whether it can be parsed.