### PR TITLE
Bugfix: ensuring quantity name uniqueness + node link names for quantities with alternatives

### DIFF
--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -90,7 +90,10 @@ def vasp_parser_with_test(vasp_nscf_and_ref, ref_retrieved_nscf):
     parser = vasp_calc.get_parserclass()(vasp_calc)
     parser.add_file_parser('_scheduler-stdout.txt', {'parser_class': ExampleFileParser, 'is_critical': False})
     success, outputs = parser.parse_with_retrieved({'retrieved': ref_retrieved_nscf})
-    return parser
+    try:
+        yield parser
+    finally:
+        parser = vasp_calc.get_parserclass()(vasp_calc)
 
 
 @ONLY_ONE_CALC

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -116,18 +116,6 @@ def test_parsable_quantities(vasp_parser_with_test):
 
 
 @ONLY_ONE_CALC
-def test_quantities_to_parse(vasp_parser_with_test):
-    """Check if quantities are added to quantities to parse correctly."""
-    parser = vasp_parser_with_test
-    # after parse_with_retrieved quantities_to_parse will be empty, so we
-    # have to set it one more time.
-    parser._check_and_validate_settings()
-    assert 'quantity2' in parser._quantities_to_parse
-    assert 'quantity_with_alternatives' not in parser._quantities_to_parse
-    assert 'quantity1' in parser._quantities_to_parse
-
-
-@ONLY_ONE_CALC
 def test_node_link_names(vasp_parser_with_test):
     """Check whether an alternative quantity representing a node will be added with the correct linkname."""
     parser = vasp_parser_with_test

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -97,6 +97,22 @@ def vasp_parser_with_test(vasp_nscf_and_ref, ref_retrieved_nscf):
 
 
 @ONLY_ONE_CALC
+def test_quantities_to_parse(vasp_nscf_and_ref, ref_retrieved_nscf):
+    """Check if quantities are added to quantities to parse correctly."""
+    from aiida.orm.data.parameter import ParameterData
+    vasp_calc, _ = vasp_nscf_and_ref
+    vasp_calc.use_settings(ParameterData(dict={'parser_settings': {'add_quantity_with_alternatives': True, 'add_quantity2': True}}))
+    parser = vasp_calc.get_parserclass()(vasp_calc)
+    parser.add_file_parser('_scheduler-stdout.txt', {'parser_class': ExampleFileParser, 'is_critical': False})
+    parser.out_folder = parser.get_folder({'retrieved': ref_retrieved_nscf})
+    parser._set_parsable_quantities()
+    parser._check_and_validate_settings()
+    assert 'quantity2' in parser._quantities_to_parse
+    assert 'quantity_with_alternatives' not in parser._quantities_to_parse
+    assert 'quantity1' in parser._quantities_to_parse
+
+
+@ONLY_ONE_CALC
 def test_parsable_quantities(vasp_parser_with_test):
     """Check whether parsable quantities are set as intended."""
     parser = vasp_parser_with_test

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -136,7 +136,9 @@ def test_node_link_names(vasp_parser_with_test):
     """Check whether an alternative quantity representing a node will be added with the correct linkname."""
     parser = vasp_parser_with_test
 
-    print parser._parsers['_scheduler-stdout.txt'].parser._parsed_data
+    print parser._parsable_quantities['structure']
+    print parser._parsable_quantities['trajectory']
+    print parser._parsable_quantities['quantity2']
     assert 'quantity2' in parser._output_nodes
     print parser._output_nodes['quantity2']
     # 'quantity2' is alternative to 'trajectory', which is not going to be parsed here.

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -194,7 +194,7 @@ class VaspParser(BaseParser):
                 continue
 
             if value:
-                self._set_node(key, value)
+                self._set_node(self._parsable_quantities[key].nodeName, value)
 
         return self.result(success=True)
 

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -34,13 +34,10 @@ DEFAULT_OPTIONS = {
 class ParsableQuantity(DictWithAttributes):
     """Container class for parsable quantities."""
 
-    QUANTITY_ATTR_DEFAULTS = {
-        'alternatives': [],
-        'parsers': [],
-    }
-
     def __init__(self, name, init, files_list):
-        super(ParsableQuantity, self).__init__(init, ParsableQuantity.QUANTITY_ATTR_DEFAULTS)
+        self.parsers = []
+        self.alternatives = []
+        super(ParsableQuantity, self).__init__(init)
         self.name = name
 
         # Check whether all files required for parsing this quantity have been retrieved and store it.
@@ -248,7 +245,14 @@ class VaspParser(BaseParser):
                 if value.is_alternative not in self._parsable_quantities:
                     # The quantity which this quantity is an alternative to is not in _parsable_quantities.
                     # Add an unparsable dummy quantity for it.
-                    self.add_parsable_quantity(value.is_alternative, {})
+                    is_node = self._parsable_quantities[quantity].nodeName == value.is_alternative
+                    self._parsable_quantities[quantity].is_node = is_node
+                    self.add_parsable_quantity(value.is_alternative, {
+                        'alternatives': [],
+                        'nodeName': self._parsable_quantities[quantity].nodeName,
+                        'is_node': is_node
+                    })
+
                 if quantity not in self._parsable_quantities[value.is_alternative].alternatives:
                     self._parsable_quantities[value.is_alternative].alternatives.append(quantity)
 

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -206,12 +206,13 @@ class VaspParser(BaseParser):
         # Gather all parsable items as defined in the file parsers.
         for filename, value in self._parsers.iteritems():
             # initialise the instance of this FileParser to None.
-            if filename in self._parsable_quantities:
-                raise RuntimeError('The quantity {0} has been defined by two FileParser classes.'.format(filename) +
-                                   ' Quantity names must be unique. If both quantities are equivalent, define one as' +
-                                   ' an alternative for the other.')
             value.parser = None
             for quantity, quantity_dict in value['parser_class'].PARSABLE_ITEMS.iteritems():
+
+                if quantity in self._parsable_quantities:
+                    raise RuntimeError('The quantity {0} defined in {1} has been defined '.format(quantity, filename) +
+                                       'by two FileParser classes. Quantity names must be unique. If both quantities ' +
+                                       'are equivalent, define one as an alternative for the other.')
                 # Create quantity objects.
                 self.add_parsable_quantity(quantity, quantity_dict, self.out_folder.get_folder_list())
 

--- a/aiida_vasp/utils/extended_dicts.py
+++ b/aiida_vasp/utils/extended_dicts.py
@@ -11,20 +11,8 @@ class DictWithAttributes(AttributeDict):
     the keys also as attributes, i.e. asking for attrdict.key
     will return the value of attrdict['key'] and so on.
 
-    If the key is not in the dict a default value will be returned. Every
-    key, that is not defined in _DEFAULT_VALUES, will simply return None.
+    If the key is not in the dict a default value will be returned.
     """
-
-    def __init__(self, init=None, defaults=None):
-        """
-        Possibly set the initial values of the dictionary from an external dictionary init.
-
-        Note that the attribute-calling syntax will work only 1 level deep.
-        """
-        super(DictWithAttributes, self).__init__(init)
-        if defaults is None:
-            defaults = {}
-        self._default_values = defaults
 
     def __getattr__(self, attr):
         """Read a key as an attribute. Return a Default value on missing key."""
@@ -35,8 +23,7 @@ class DictWithAttributes(AttributeDict):
         self[attr] = value
 
     def get(self, attr):
-        default = self['_default_values'].get(attr, None)
         if attr in self:
             return self[attr]
 
-        return default
+        return None


### PR DESCRIPTION
My previous update had at least two bugs in it. 
- The warning ensuring that quantity identifiers are unique was in the wrong place checking the wrong thing and therefore doing nothing.
- In case that an alternative quantity representing a node was parsed, it would not have gotten the correct link name.

Both issues did not have any effect currently, because there are no quantities with alternatives or non unique quantity identifiers.