### PR TITLE
Fix Issue #160: replaced delegate decorator with a callable list

### DIFF
--- a/aiida_vasp/io/parser.py
+++ b/aiida_vasp/io/parser.py
@@ -160,7 +160,7 @@ class BaseFileParser(BaseParser):
         super(BaseFileParser, self).__init__()
         self._vasp_parser = calc_parser_cls
         if calc_parser_cls is not None:
-            calc_parser_cls.get_quantity.add_listener(self.get_quantity)
+            calc_parser_cls.get_quantity.append(self.get_quantity)
 
         self._parsable_items = {}
         self._parsed_data = {}

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -1,9 +1,12 @@
 #encoding: utf-8
+
+# pylint: disable=no-member
+# Reason: pylint erroneously complains about non existing member 'get_quantity', which will be set in __init__.
 """AiiDA Parser for a aiida_vasp.VaspCalculation"""
 
 from aiida_vasp.parsers.base import BaseParser
 from aiida_vasp.parsers.file_parser_definitions import get_file_parser_set
-from aiida_vasp.utils.delegates import delegate
+from aiida_vasp.utils.delegates import Delegate
 from aiida_vasp.utils.extended_dicts import DictWithAttributes
 
 LINKNAME_DICT = {
@@ -109,6 +112,9 @@ class VaspParser(BaseParser):
 
     def __init__(self, calc):
         super(VaspParser, self).__init__(calc)
+
+        # Initialise the 'get_quantity' delegate:
+        setattr(self, 'get_quantity', Delegate())
 
         self.out_folder = None
 
@@ -305,12 +311,6 @@ class VaspParser(BaseParser):
                     continue
                 file_to_parse = self.get_file(filename)
                 self._parsers[filename].parser = self._parsers[filename]['parser_class'](file_to_parse, calc_parser_cls=self)
-
-    # pylint: disable=unused-argument, no-self-use
-    @delegate()
-    def get_quantity(self, quantity, settings):
-        """Delegate to which the FileParsers will subscribe their get_quantity methods when they are initialised."""
-        return {quantity: None}
 
     def get_inputs(self, quantity):
         """

--- a/aiida_vasp/utils/delegates.py
+++ b/aiida_vasp/utils/delegates.py
@@ -1,81 +1,15 @@
-"""Module containing various decorators implementing delegate types."""
-from functools import update_wrapper
+"""Module containing decorators and classes implementing delegate types."""
 
 
-def delegate():
-    """
-    Get a decorator adding attributes to add or remove functions to a list of functions.
+class Delegate(list):
+    """A callable list, that will call every function inside the list and delegate the arguments."""
 
-    When the decorated function is called, all functions in the list will be called. It
-    will return a list of all the return values of the subscribed functions. If the
-    delegate does not have any subscribers the code from the delegate method itself will
-    be executed. The basic usage is outlined in the corresponding utils.tests.test_delegates.
-    For a fully fleshed out example look at the VaspParser and the BaseFileParser. The idea is
-    that there is a class e.g.
-
-    class VaspParser():
-
-        @delegate()
-        def parse_quantity(self, quantity, inputs):
-            return None
-
-    managing a number of instances of classes e.g.
-
-    class FileParser():
-
-        def __init__(self, cls):
-            cls.parse_quantity.add_listener(self.parse_file)
-
-        def parse_file(self, quantity, inputs):
-
-            if can_parse(quantity):
-               return parse(quantity, inputs)
-
-            return None
-
-    The FileParsers can be instantiated somewhere in the code by giving them an instance
-    of the VaspParser i.e.
-
-    vasp_parser = VaspParser()
-    FileParser(vasp_parser)
-
-    and they will subscribe their parse_file method to the parse_quantity delegate of the VaspParser.
-    The VaspParser can then parse a given quantity by calling its parse_quantity method
-
-    self.parse_quantity(inputs)
-
-    which will then call all the methods subscribed to it. The advantage is that the
-    VaspParser itself, does not need to keep track of all the FileParser objects. In addition
-    it does not need to decide, which of the FileParsers to call. This logic can be moved to
-    the FileParsers, who may decide whether they can parse that quantity based on the input.
-    """
-
-    def decorator(meth):
-        """Decorate a class method to delegate kwargs."""
-
-        meth.listeners = []
-
-        def add_listener(func):
-            meth.listeners.append(func)
-
-        def remove_listener(func):
-            if func in meth.listeners:
-                meth.listeners.remove(func)
-
-        setattr(meth, 'add_listener', add_listener)
-        setattr(meth, 'remove_listener', remove_listener)
-
-        def wrapper(*args, **kwargs):
-            """Wrap the method to be delegated."""
-            results = []
-            for func in meth.listeners:
-                results.append(func(*args[1:], **kwargs))
-            for result in results:
-                if result:
-                    return result
-            return meth(*args, **kwargs)
-
-        update_wrapper(wrapper, meth)
-        return wrapper
-
-    return decorator
+    def __call__(self, *args, **kwargs):
+        """Call all the functions subscribed to this list and return their result."""
+        results = []
+        for func in self:
+            results.append(func(*args, **kwargs))
+        for result in results:
+            if result:
+                return result
+        return {args[0]: None}

--- a/aiida_vasp/utils/tests/test_delegate.py
+++ b/aiida_vasp/utils/tests/test_delegate.py
@@ -1,16 +1,18 @@
-"""Test the delegate decorator"""
-# pylint: disable=unused-import,redefined-outer-name,unused-argument,unused-wildcard-import,wildcard-import,no-member,no-self-use,missing-docstring
+# pylint: disable=unused-import,too-few-public-methods,missing-docstring,no-self-use,no-member
+"""Test the Delegate class."""
 
 import pytest
 
-from aiida_vasp.utils.delegates import delegate
+from aiida_vasp.utils.delegates import Delegate
 
 
 class VaspParser(object):
 
-    @delegate()
-    def get_quantity(self, inputs):
-        return None
+    def __init__(self):
+        super(VaspParser, self).__init__()
+
+        # Initialise the 'get_quantity' delegate:
+        setattr(self, 'get_quantity', Delegate())
 
 
 class FileParser(object):
@@ -18,19 +20,19 @@ class FileParser(object):
     def __init__(self, cls):
         self._vasp_parser = cls
         if cls is not None:
-            self._vasp_parser.get_quantity.add_listener(self.parse_file)
+            self._vasp_parser.get_quantity.append(self.parse_file)
 
     def parse_file(self, inputs):
         return inputs
 
 
 def test_delegate():
-    """Test the functionality of the delegate() wrapper"""
+    """Test the functionality of the Delegate class wrapper"""
 
     vasp_parser = VaspParser()
-    assert not vasp_parser.get_quantity.listeners
+    assert not vasp_parser.get_quantity
     file_parser = FileParser(vasp_parser)
     inputs = 'This is a test input'
     assert vasp_parser.get_quantity(inputs) == inputs
-    vasp_parser.get_quantity.remove_listener(file_parser.parse_file)
-    assert vasp_parser.get_quantity.listeners == []
+    vasp_parser.get_quantity.remove(file_parser.parse_file)
+    assert vasp_parser.get_quantity == []


### PR DESCRIPTION
The delegate decorator introduced a global list of FileParsers on the `VaspParser` class leading to two instances of the `VaspParser` sharing the same set of FileParsers. This has caused issues with `VaspParser` instances being interconnected in a case, where they have been instantiated successively from the same import of `VaspParser`. 

This fix will replace the delegate decorator with the `Delegate` class, which is supposed to be just a callable list. This one can be instantiated per instance of the `VaspParser` and should solve the above stated issue.