### PR TITLE
fix latest compatibility issues for aiida 1.0 and 0.12

### DIFF
--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -266,9 +266,9 @@ class VaspParser(BaseParser):
                 continue
             quantity = key[4:]
             if quantity not in self._parsable_quantities:
-                self.logger.warning('{0} has been requested by setting add_{0}'.format(quantity) +
-                                    ' however it has not been implemented. Please check the docstrings' +
-                                    ' in aiida_vasp.parsers.vasp.py for valid input.')
+                self.logger.warning(
+                    '{0} has been requested by setting add_{0}'.format(quantity) +
+                    ' however it has not been implemented. Please check the docstrings' + ' in aiida_vasp.parsers.vasp.py for valid input.')
                 continue
 
             # Found a node, which should be added, add it to the quantities to parse.

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -266,9 +266,9 @@ class VaspParser(BaseParser):
                 continue
             quantity = key[4:]
             if quantity not in self._parsable_quantities:
-                self.logger.warning(
-                    '{0} has been requested by setting add_{0}'.format(quantity) +
-                    ' however it has not been implemented. Please check the docstrings' + ' in aiida_vasp.parsers.vasp.py for valid input.')
+                self.logger.warning('{0} has been requested by setting add_{0}'.format(quantity) +
+                                    ' however it has not been implemented. Please check the docstrings' +
+                                    ' in aiida_vasp.parsers.vasp.py for valid input.')
                 continue
 
             # Found a node, which should be added, add it to the quantities to parse.

--- a/aiida_vasp/utils/tests/test_aiida_compat.py
+++ b/aiida_vasp/utils/tests/test_aiida_compat.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from aiida_vasp.utils.aiida_utils import get_current_user, backend_obj_users
+from aiida_vasp.utils.aiida_utils import get_current_user, backend_obj_users, get_data_class, get_data_node
 from aiida_vasp.utils.fixtures import aiida_env
 
 
@@ -16,3 +16,11 @@ def test_get_current_user(aiida_env):
     assert user.first_name
     assert user.last_name
     assert user.email
+
+
+def test_get_base_data(aiida_env):
+    bool_cls = get_data_class('bool')
+    bool_obj = get_data_node('bool', True)
+    from aiida.orm.data.base import Bool
+    assert bool_cls == Bool
+    assert isinstance(bool_obj, Bool)

--- a/aiida_vasp/workflows/base.py
+++ b/aiida_vasp/workflows/base.py
@@ -7,7 +7,6 @@ should be handled on this level, so that every workflow can profit from it.
 Anything related to a subset of use cases must be handled in a subclass.
 """
 from aiida.work.workchain import while_
-from aiida.work.db_types import Str
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.exceptions import NotExistent
 from aiida.orm import Code, CalculationFactory
@@ -55,7 +54,7 @@ class VaspBaseWf(BaseRestartWorkChain):
         spec.input('code', valid_type=Code)
         spec.input('structure', valid_type=(get_data_class('structure'), get_data_class('cif')))
         spec.input('kpoints', valid_type=get_data_class('array.kpoints'))
-        spec.input('potcar_family', valid_type=Str)
+        spec.input('potcar_family', valid_type=get_data_class('str'))
         spec.input('potcar_mapping', valid_type=get_data_class('parameter'))
         spec.input('incar', valid_type=get_data_class('parameter'))
         spec.input('wavecar', valid_type=get_data_class('vasp.wavefun'), required=False)


### PR DESCRIPTION
In AiiDA-core some things have been moved / removed. Add compatibility layers to stay compatible with both the 1.0 and the 0.12 series:

* get `aiida.work.db_types` and `aiida.orm.data.base` members through `get_data_class` and `get_data_node` now
* `BaseRestartWorkchain`: replace `on_destroy` with `on_terminated` only in the newer version