### PR TITLE
Fix: #179 requesting forces as part of 'output_parameters'

### DIFF
--- a/aiida_vasp/io/vasprun.py
+++ b/aiida_vasp/io/vasprun.py
@@ -156,6 +156,7 @@ class VasprunParser(BaseFileParser):
     def __init__(self, *args, **kwargs):
         super(VasprunParser, self).__init__(*args, **kwargs)
         self.init_with_kwargs(**kwargs)
+        self._settings = {}
 
     def _init_with_file_path(self, path):
         """Init with a filepath."""
@@ -187,6 +188,7 @@ class VasprunParser(BaseFileParser):
         settings = inputs.get('settings', DEFAULT_OPTIONS)
         if not settings:
             settings = DEFAULT_OPTIONS
+        self._settings = settings
 
         quantities_to_parse = settings.get('quantities_to_parse', DEFAULT_OPTIONS['quantities_to_parse'])
         result = {}
@@ -311,8 +313,7 @@ class VasprunParser(BaseFileParser):
         outcar_parameters = self._parsed_data.get('ocp_parameters')
         if outcar_parameters is not None:
             parameters.update(outcar_parameters)
-        settings = self._parsed_data.get('settings', DEFAULT_OPTIONS)
-        for quantity in settings.get('output_params', DEFAULT_OPTIONS['output_params']):
+        for quantity in self._settings.get('output_params', DEFAULT_OPTIONS['output_params']):
             parameters[quantity] = getattr(self, quantity)
 
         output_parameters = get_data_node('parameter', dict=parameters)
@@ -391,9 +392,8 @@ class VasprunParser(BaseFileParser):
         frs = self._data_obj.get_forces("final")
         if frs is None:
             return None
-        forces = get_data_class('array')()
-        forces.set_array('forces', frs)
-        return forces
+
+        return frs
 
     @property
     def final_forces(self):

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -26,21 +26,6 @@ LINKNAME_DICT = {
     'wavecar': 'wavecar',
 }
 
-ALLOWED_TYPES = {
-    'parameters': 'parameters',
-    'kpoints': 'array.kpoints',
-    'structure': 'structure',
-    'trajectory': 'array.trajectory',
-    'bands': 'array.bands',
-    'dos': 'array',
-    'energies': 'array',
-    'projectors': 'array',
-    'born_charges': 'array',
-    'dielectrics': 'array',
-    'hessian': 'array',
-    'dynmat': 'array'
-}
-
 DEFAULT_OPTIONS = {
     'add_trajectory': False,
     'add_bands': False,
@@ -126,6 +111,8 @@ class VaspParser(BaseParser):
         'kpoints':    KpointsData node parsed from IBZKPT.
         'wavecar':    FileData node containing the WAVECAR file.
         'chgcar':     FileData node containing the CHGCAR file.
+
+    * `output_params`: A list of quantities, that should be added to the 'output_parameters' node.
 
     * `file_parser_set`: String (DEFAULT = 'default').
 
@@ -228,14 +215,8 @@ class VaspParser(BaseParser):
         self._set_file_parsers()
 
         # Parse all implemented quantities in the quantities_to_parse list.
-        print self._quantities_to_parse
         while self._quantities_to_parse:
             quantity = self._quantities_to_parse.pop(0)
-            balla = self.get_quantity(quantity, self._settings)
-            if quantity == 'parameters':
-                print self._settings
-                print self._output_nodes
-                print balla['parameters'].get_dict()
             self._output_nodes.update(self.get_quantity(quantity, self._settings))
 
         # Add output nodes if the corresponding data exists.


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

fixes: #179 

blocks: #175 

is blocked by:

None of the above but is still related to the following:

## Description

This is a quick fix for #179, which prevents requesting 'forces' for parsing in the current implementation. The current implementation works under the following two assumptions:

- The 'forces' quantity is stored in the 'output_parameters' node in the QE plugin.
- The quantities that will be stored in 'output_parameters' can be determined by setting `'output_params': [<quantities>]`.

This system may be changed later, if those requirements change.