### PR TITLE
pin prospector, add missing docstring

### DIFF
--- a/aiida_vasp/workflows/base.py
+++ b/aiida_vasp/workflows/base.py
@@ -130,6 +130,7 @@ class VaspBaseWf(BaseRestartWorkChain):
 
     @override
     def on_except(self, exc_info):
+        """Handle excepted state."""
 
         last_calc = self.ctx.calculations[-1] if self.ctx.calculations else None
         if last_calc:

--- a/setup.json
+++ b/setup.json
@@ -48,8 +48,8 @@
     "extras_require": {
         "dev": [
             "pre-commit", 
-            "prospector <= 1.0", 
-            "pylint", 
+            "prospector == 0.12.11", 
+            "pylint == 1.9.3", 
             "flake8", 
             "yapf", 
             "coverage", 

--- a/setup.json
+++ b/setup.json
@@ -48,7 +48,7 @@
     "extras_require": {
         "dev": [
             "pre-commit", 
-            "prospector", 
+            "prospector <= 1.0", 
             "pylint", 
             "flake8", 
             "yapf", 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [X] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

should unblock all PRs that are stuck due to prospector 1.0 throwing a KeyError.

## Description

prospector has released 1.0, which throws the following error:
```
Traceback (most recent call last):
  File "/home/hauselmann/miniconda2/envs/aiida-dev/bin/prospector", line 11, in <module>
    sys.exit(main())
  File "/home/hauselmann/miniconda2/envs/aiida-dev/lib/python2.7/site-packages/prospector/run.py", line 174, in main
    prospector.print_messages()
  File "/home/hauselmann/miniconda2/envs/aiida-dev/lib/python2.7/site-packages/prospector/run.py", line 132, in print_messages
    formatter = FORMATTERS[output_format](self.summary, self.messages, self.config.profile)
KeyError: None
```

There is already an issue on their repo, until this is fixed, we pin the version to <= 1.0