### PR TITLE
fix the potcar command to work with aiida develop

### DIFF
--- a/aiida_vasp/commands/options.py
+++ b/aiida_vasp/commands/options.py
@@ -1,50 +1,51 @@
 """Common click options for verdi commands"""
 import click
 
+try:
+    from aiida.cmdline.params.options import OverridableOption, FORCE, DESCRIPTION  # pylint: disable=unused-import
+except ImportError:
+    # pylint: disable=too-few-public-methods
+    class OverridableOption(object):
+        """
+        Wrapper around click option that increases reusability
 
-# pylint: disable=too-few-public-methods
-class OverridableOption(object):
-    """
-    Wrapper around click option that increases reusability
+        Click options are reusable already but sometimes it can improve the user interface to for example customize a help message
+        for an option on a per-command basis. Sometimes the option should be prompted for if it is not given. On some commands an option
+        might take any folder path, while on another the path only has to exist.
 
-    Click options are reusable already but sometimes it can improve the user interface to for example customize a help message
-    for an option on a per-command basis. Sometimes the option should be prompted for if it is not given. On some commands an option
-    might take any folder path, while on another the path only has to exist.
+        Overridable options store the arguments to click.option and only instanciate the click.Option on call, kwargs given to ``__call__``
+        override the stored ones.
 
-    Overridable options store the arguments to click.option and only instanciate the click.Option on call, kwargs given to ``__call__``
-    override the stored ones.
+        Example::
 
-    Example::
+            FOLDER = OverridableOption('--folder', type=click.Path(file_okay=False), help='A folder')
 
-        FOLDER = OverridableOption('--folder', type=click.Path(file_okay=False), help='A folder')
+            @click.command()
+            @FOLDER(help='A folder, will be created if it does not exist')
+            def ls_or_create(folder):
+                click.echo(os.listdir(folder))
 
-        @click.command()
-        @FOLDER(help='A folder, will be created if it does not exist')
-        def ls_or_create(folder):
-            click.echo(os.listdir(folder))
+            @click.command()
+            @FOLDER(help='An existing folder', type=click.Path(exists=True, file_okay=False, readable=True)
+            def ls(folder)
+                click.echo(os.listdir(folder))
+        """
 
-        @click.command()
-        @FOLDER(help='An existing folder', type=click.Path(exists=True, file_okay=False, readable=True)
-        def ls(folder)
-            click.echo(os.listdir(folder))
-    """
+        def __init__(self, *args, **kwargs):
+            """Store the defaults."""
+            self.args = args
+            self.kwargs = kwargs
 
-    def __init__(self, *args, **kwargs):
-        """Store the defaults."""
-        self.args = args
-        self.kwargs = kwargs
+        def __call__(self, **kwargs):
+            """Override kwargs (no name changes) and return option."""
+            kw_copy = self.kwargs.copy()
+            kw_copy.update(kwargs)
+            return click.option(*self.args, **kw_copy)
 
-    def __call__(self, **kwargs):
-        """Override kwargs (no name changes) and return option."""
-        kw_copy = self.kwargs.copy()
-        kw_copy.update(kwargs)
-        return click.option(*self.args, **kw_copy)
-
+    FORCE = OverridableOption('-f', '--force', is_flag=True, help='Do not ask for confirmation')
+    DESCRIPTION = OverridableOption('-D', '--description', help='(text) description')
 
 FAMILY_NAME = OverridableOption('--name', required=True, help='Name of the POTCAR family')
 PATH = OverridableOption('--path', default='.', type=click.Path(exists=True), help='Path to the folder')
-
-FORCE = OverridableOption('-f', '--force', is_flag=True, help='Do not ask for confirmation')
-DESCRIPTION = OverridableOption('-D', '--description', help='(text) description')
 
 DRY_RUN = OverridableOption('--dry-run', is_flag=True, is_eager=True, help='do not commit to database or modify configuration files')

--- a/aiida_vasp/commands/potcar.py
+++ b/aiida_vasp/commands/potcar.py
@@ -3,16 +3,13 @@ import click
 from click_spinner import spinner as cli_spinner
 import tabulate
 
-try:
-    from aiida.cmdline.commands import data_cmd as verdi_data
-except ImportError:
-    from aiida.cmdline.commands import verdi_data
-
-from aiida_vasp.utils.aiida_utils import get_data_class
+from aiida_vasp.utils.aiida_utils import get_data_class, cmp_load_verdi_data
 from aiida_vasp.commands import options
 
+VERDI_DATA = cmp_load_verdi_data()
 
-@verdi_data.group('vasp-potcar')
+
+@VERDI_DATA.group('vasp-potcar')
 def potcar():
     """Top level command for handling VASP POTCAR files."""
 

--- a/aiida_vasp/utils/aiida_utils.py
+++ b/aiida_vasp/utils/aiida_utils.py
@@ -94,3 +94,32 @@ def aiida_version():
 
 def cmp_version(string):
     return version.parse(string)
+
+
+def cmp_load_verdi_data():
+    """Load the verdi data click command group for any version since 0.11."""
+    verdi_data = None
+    import_errors = []
+
+    try:
+        from aiida.cmdline.commands import data_cmd as verdi_data
+    except ImportError as err:
+        import_errors.append(err)
+
+    if not verdi_data:
+        try:
+            from aiida.cmdline.commands import verdi_data
+        except ImportError as err:
+            import_errors.append(err)
+
+    if not verdi_data:
+        try:
+            from aiida.cmdline.commands.cmd_data import verdi_data
+        except ImportError as err:
+            import_errors.append(err)
+
+    if not verdi_data:
+        err_messages = '\n'.join([' * {}'.format(err) for err in import_errors])
+        raise ImportError('The verdi data base command group could not be found:\n' + err_messages)
+
+    return verdi_data


### PR DESCRIPTION
I, the author consider this PR
 - [X] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

AiiDA-core recently moved the `verdi_data` click command group and added some reusable click options. This PR adapts to those changes while keeping backwards compatibility.