### PR TITLE
Fixed VasprunParsers behaviour if vasprun.xml is unparsable

### DIFF
--- a/aiida_vasp/io/vasprun.py
+++ b/aiida_vasp/io/vasprun.py
@@ -173,6 +173,14 @@ class VasprunParser(BaseFileParser):
 
         quantities_to_parse = self.settings.get('quantities_to_parse', DEFAULT_OPTIONS['quantities_to_parse'])
         result = {}
+
+        if self._xml is None:
+            # parsevasp threw an exception, which means vasprun.xml could not be parsed.
+            for quantity in quantities_to_parse:
+                if quantity in self._parsable_items:
+                    result[quantity] = None
+            return result
+
         for quantity in quantities_to_parse:
             if quantity in self._parsable_items:
                 result[quantity] = getattr(self, quantity)

--- a/aiida_vasp/io/vasprun.py
+++ b/aiida_vasp/io/vasprun.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from parsevasp.vasprun import Xml
 from parsevasp import constants as parsevaspct
-from aiida_vasp.io.parser import BaseFileParser
+from aiida_vasp.io.parser import BaseFileParser, SingleFile
 from aiida_vasp.utils.aiida_utils import get_data_class, get_data_node
 
 DEFAULT_OPTIONS = {
@@ -15,24 +15,6 @@ DEFAULT_OPTIONS = {
     'energy_type': ['energy_no_entropy'],
     'output_params': []
 }
-
-
-class ExtendedXml(Xml):
-    """
-    Extension of parsevasp's Xml class.
-
-    To keep parser interfaces similar.
-
-    """
-
-    @property
-    def path(self):
-        return self._file_path
-
-    def write(self, dst):
-        """Copy vasprun.xml to destination."""
-        import shutil
-        shutil.copyfile(self._file_path, dst)
 
 
 class VasprunParser(BaseFileParser):
@@ -155,22 +137,22 @@ class VasprunParser(BaseFileParser):
 
     def __init__(self, *args, **kwargs):
         super(VasprunParser, self).__init__(*args, **kwargs)
+        self._xml = None
         self.init_with_kwargs(**kwargs)
 
     def _init_with_file_path(self, path):
         """Init with a filepath."""
         self._parsed_data = {}
         self._parsable_items = self.__class__.PARSABLE_ITEMS
+        self._data_obj = SingleFile(path=path)
 
         # Since vasprun.xml can be fairly large, we will parse it only
-        # once and store the parsevasp Xml object instead of the filepath.
-        # Also, make sure the k-point index runs before the band index as
-        # per BandsData spec.
+        # once and store the parsevasp Xml object.
         try:
-            self._data_obj = ExtendedXml(file_path=path, k_before_band=True)
+            self._xml = Xml(file_path=path, k_before_band=True)
         except SystemExit:
             self._logger.warning("Parsevasp exited abruptly. Returning None.")
-            self._data_obj = None
+            self._xml = None
 
     def _init_with_data(self, data):
         """Init with singleFileData."""
@@ -228,7 +210,7 @@ class VasprunParser(BaseFileParser):
         """Fetch eigenvalues from parsevasp."""
 
         # fetch eigenvalues
-        eigenvalues = self._data_obj.get_eigenvalues()
+        eigenvalues = self._xml.get_eigenvalues()
 
         if eigenvalues is None:
             # eigenvalues not present
@@ -253,7 +235,7 @@ class VasprunParser(BaseFileParser):
         """Fetch occupations from parsevasp."""
 
         # fetch occupations
-        occupations = self._data_obj.get_occupancies()
+        occupations = self._xml.get_occupancies()
 
         if occupations is None:
             # occupations not present, should not really happen?
@@ -278,7 +260,7 @@ class VasprunParser(BaseFileParser):
         """Fetch occupations from parsevasp."""
 
         # fetch occupations
-        occupations = self._data_obj.get_occupancies()
+        occupations = self._xml.get_occupancies()
 
         if occupations is None:
             # occupations not present, should not really happen?
@@ -323,8 +305,8 @@ class VasprunParser(BaseFileParser):
     def kpoints(self):
         """Fetch the kpoints from parsevasp an store in KpointsData."""
 
-        kpts = self._data_obj.get_kpoints()
-        kptsw = self._data_obj.get_kpointsw()
+        kpts = self._xml.get_kpoints()
+        kptsw = self._xml.get_kpointsw()
         kpoints_data = None
         if (kpts is not None) and (kptsw is not None):
             # create a KpointsData object and store k-points
@@ -360,7 +342,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        last_lattice = self._data_obj.get_lattice("final")
+        last_lattice = self._xml.get_lattice("final")
         if last_lattice is not None:
             return _build_structure(last_lattice)
         return None
@@ -388,7 +370,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        frs = self._data_obj.get_forces("final")
+        frs = self._xml.get_forces("final")
         if frs is None:
             return None
 
@@ -416,7 +398,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        strs = self._data_obj.get_stress("final")
+        strs = self._xml.get_stress("final")
         if strs is None:
             return None
         stress = get_data_class('array')()
@@ -444,11 +426,11 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        unitcell = self._data_obj.get_unitcell("all")
-        positions = self._data_obj.get_positions("all")
-        species = self._data_obj.get_species()
-        forces = self._data_obj.get_forces("all")
-        stress = self._data_obj.get_stress("all")
+        unitcell = self._xml.get_unitcell("all")
+        positions = self._xml.get_positions("all")
+        species = self._xml.get_species()
+        forces = self._xml.get_forces("all")
+        stress = self._xml.get_stress("all")
         # make sure all are sorted, first to last calculation
         # (species is constant)
         unitcell = sorted(unitcell.items())
@@ -561,7 +543,7 @@ class VasprunParser(BaseFileParser):
             # self consistent steps, which contain a different
             # number of elements, not supported by Numpy's std.
             # arrays
-            enrgies = self._data_obj.get_energies(status="all", etype=etype, nosc=nosc)
+            enrgies = self._xml.get_energies(status="all", etype=etype, nosc=nosc)
             if enrgies is None:
                 return None
             enrgy = get_data_class('array')()
@@ -584,7 +566,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        proj = self._data_obj.get_projectors()
+        proj = self._xml.get_projectors()
         if proj is None:
             return None
         projectors = get_data_class('array')()
@@ -612,7 +594,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        diel = self._data_obj.get_dielectrics()
+        diel = self._xml.get_dielectrics()
         if diel is None:
             return None
         dielectrics = get_data_class('array')()
@@ -631,7 +613,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        brn = self._data_obj.get_born()
+        brn = self._xml.get_born()
         if brn is None:
             return None
         born = get_data_class('array')()
@@ -647,7 +629,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        hessian = self._data_obj.get_hessian()
+        hessian = self._xml.get_hessian()
         if hessian is None:
             return None
         hess = get_data_class('array')()
@@ -663,7 +645,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        dynmat = self._data_obj.get_dynmat()
+        dynmat = self._xml.get_dynmat()
         if dynmat is None:
             return None
         dyn = get_data_class('array')()
@@ -680,7 +662,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        dos = self._data_obj.get_dos()
+        dos = self._xml.get_dos()
         if dos is None:
             return None
         densta = get_data_class('array')()
@@ -711,7 +693,7 @@ class VasprunParser(BaseFileParser):
     def fermi_level(self):
         """Fetch Fermi level."""
 
-        return self._data_obj.get_fermi_level()
+        return self._xml.get_fermi_level()
 
 
 def _build_structure(lattice):


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

- The `parsevasp.Xml` object is now stored in `self._xml` instead of `self._data_obj`, which gets rid of the ExtendedXml class, `self._data_obj` is now the usual `SingleFile` object.
- `parse_file` will now check, whether `self._xml is None`, which would be the case if the vasprun.xml file could not be parsed successfully. 