### PR TITLE
Removed obsolete/redundant 'parsers' card from quantity_definitions

### DIFF
--- a/aiida_vasp/io/chgcar.py
+++ b/aiida_vasp/io/chgcar.py
@@ -10,7 +10,6 @@ class ChgcarParser(BaseFileParser):
     PARSABLE_ITEMS = {
         'chgcar': {
             'inputs': [],
-            'parsers': ['CHGCAR'],
             'nodeName': 'chgcar',
             'prerequisites': []
         },

--- a/aiida_vasp/io/doscar.py
+++ b/aiida_vasp/io/doscar.py
@@ -28,7 +28,6 @@ class DosParser(BaseFileParser):
     PARSABLE_ITEMS = {
         'doscar-dos': {
             'inputs': [],
-            'parsers': ['DOSCAR'],
             'nodeName': 'dos',
             'prerequisites': [],
             'alternatives': ['dos']

--- a/aiida_vasp/io/eigenval.py
+++ b/aiida_vasp/io/eigenval.py
@@ -14,7 +14,6 @@ class EigParser(BaseFileParser):
     PARSABLE_ITEMS = {
         'eigenval-bands': {
             'inputs': ['structure', 'kpoints', 'occupations'],
-            'parsers': ['EIGENVAL', 'vasprun.xml'],
             'nodeName': 'bands',
             'prerequisites': ['structure', 'occupations'],
             'alternatives': ['bands']

--- a/aiida_vasp/io/kpoints.py
+++ b/aiida_vasp/io/kpoints.py
@@ -21,7 +21,6 @@ class KpParser(BaseFileParser):
     PARSABLE_ITEMS = {
         'kpoints-kpoints': {
             'inputs': [],
-            'parsers': ['EIGENVAL', 'IBZKPT'],
             'nodeName': 'kpoints',
             'prerequisites': [],
             'alternatives': ['kpoints']

--- a/aiida_vasp/io/outcar.py
+++ b/aiida_vasp/io/outcar.py
@@ -19,31 +19,26 @@ class OutcarParser(BaseFileParser):
     PARSABLE_ITEMS = {
         'outcar-volume': {
             'inputs': ['parameters'],
-            'parsers': ['OUTCAR'],
             'nodeName': 'parameters',
             'prerequisites': []
         },
         'outcar-energies': {
             'inputs': ['parameters'],
-            'parsers': ['OUTCAR'],
             'nodeName': 'parameters',
             'prerequisites': []
         },
         'outcar-fermi_level': {
             'inputs': ['parameters'],
-            'parsers': ['OUTCAR'],
             'nodeName': 'parameters',
             'prerequisites': []
         },
         'outcar-parameters': {
             'inputs': [],
-            'parsers': ['OUTCAR'],
             'nodeName': 'parameters',
             'prerequisites': []
         },
         'symmetries': {
             'inputs': [],
-            'parsers': ['OUTCAR'],
             'nodeName': 'parameters',
             'prerequisites': []
         }

--- a/aiida_vasp/io/poscar.py
+++ b/aiida_vasp/io/poscar.py
@@ -33,7 +33,6 @@ class PoscarParser(BaseFileParser):
     PARSABLE_ITEMS = {
         'poscar-structure': {
             'inputs': [],
-            'parsers': ['CONTCAR'],
             'nodeName': 'structure',
             'prerequisites': [],
             'alternatives': ['structure']

--- a/aiida_vasp/io/vasprun.py
+++ b/aiida_vasp/io/vasprun.py
@@ -23,112 +23,96 @@ class VasprunParser(BaseFileParser):
     PARSABLE_ITEMS = {
         'structure': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'structure',
             'prerequisites': [],
             'alternatives': ['poscar-structure']
         },
         'bands': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'bands',
             'prerequisites': [],
             'alternatives': ['eigenval-bands']
         },
         'dos': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'dos',
             'prerequisites': [],
             'alternatives': ['doscar-dos']
         },
         'kpoints': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'kpoints',
             'prerequisites': [],
             'alternatives': ['kpoints-kpoints']
         },
         'occupations': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'occupations',
             'prerequisites': [],
             #'alternatives': ['eigenval-occupations']
         },
         'trajectory': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'trajectory',
             'prerequisites': [],
             #'alternatives': ['xdatcar-trajectory']
         },
         'energies': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'energies',
             'prerequisites': [],
             'alternatives': ['outcar-energies']
         },
         'projectors': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'projectors',
             'prerequisites': [],
             #'alternatives': ['procar-projectors']
         },
         'dielectrics': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'dielectrics',
             'prerequisites': [],
             #'alternatives': ['outcar-dielectrics']
         },
         'final_stress': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': '',
             'prerequisites': [],
             #'alternatives': ['outcar-final_stress']
         },
         'final_forces': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': '',
             'prerequisites': [],
             #'alternatives': ['outcar-final_stress']
         },
         'final_structure': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': '',
             'prerequisites': [],
             #'alternatives': ['outcar-final_structure']
         },
         'born_charges': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'born_charges',
             'prerequisites': [],
             #'alternatives': ['outcar-born_charges']
         },
         'hessian': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'hessian',
             'prerequisites': [],
             #'alternatives': ['outcar-hessian']
         },
         'dynmat': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'dynmat',
             'prerequisites': [],
             #'alternatives': ['outcar-dynmat']
         },
         'parameters': {
             'inputs': [],
-            'parsers': ['vasprun.xml'],
             'nodeName': 'parameters',
             'prerequisites': [],
             'alternatives': ['outcar-parameters']

--- a/aiida_vasp/io/wavecar.py
+++ b/aiida_vasp/io/wavecar.py
@@ -10,7 +10,6 @@ class WavecarParser(BaseFileParser):
     PARSABLE_ITEMS = {
         'wavecar': {
             'inputs': [],
-            'parsers': ['WAVECAR'],
             'nodeName': 'wavecar',
             'prerequisites': []
         },

--- a/aiida_vasp/parsers/parser_manager.py
+++ b/aiida_vasp/parsers/parser_manager.py
@@ -86,10 +86,10 @@ class ParserManager(object):
         """Set the specific FileParsers."""
 
         for quantity in self._quantities_to_parse:
-            for filename in self._quantities.get_by_name(quantity).parsers:
-                if self._parsers[filename].parser is not None:
-                    # This parser has already been checked, i.e. take the first
-                    # available in the list that can be parsed (i.e. file exists)
-                    continue
-                file_to_parse = self._vasp_parser.get_file(filename)
-                self._parsers[filename].parser = self._parsers[filename]['parser_class'](self._vasp_parser, file_path=file_to_parse)
+            file_name = self._quantities.get_by_name(quantity).file_name
+            if self._parsers[file_name].parser is not None:
+                # This parser has already been checked, i.e. take the first
+                # available in the list that can be parsed (i.e. file exists)
+                continue
+            file_to_parse = self._vasp_parser.get_file(file_name)
+            self._parsers[file_name].parser = self._parsers[file_name]['parser_class'](self._vasp_parser, file_path=file_to_parse)

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -15,29 +15,20 @@ class ExampleFileParser(BaseFileParser):
     """Example FileParser class for testing VaspParsers functionality."""
 
     PARSABLE_ITEMS = {
-        'quantity_with_alternatives': {
-            'inputs': [],
-            'parsers': ['DUMMY'],
-            'nodeName': 'structure',
-            'prerequisites': [],
-        },
         'quantity1': {
             'inputs': [],
-            'parsers': ['CONTCAR'],
             'nodeName': 'structure',
             'is_alternative': 'quantity_with_alternatives',
             'prerequisites': []
         },
         'quantity2': {
             'inputs': [],
-            'parsers': ['_scheduler-stdout.txt'],
             'nodeName': 'trajectory',
             'is_alternative': 'trajectory',
             'prerequisites': ['quantity1']
         },
         'quantity3': {
             'inputs': [],
-            'parsers': ['CONTCAR'],
             'nodeName': '',
             'is_alternative': 'non_existing_quantity',
             'prerequisites': ['quantity_with_alternatives']
@@ -61,9 +52,13 @@ class ExampleFileParser2(BaseFileParser):
     """Example class for testing non unique quantity identifiers."""
 
     PARSABLE_ITEMS = {
+        'quantity_with_alternatives': {
+            'inputs': [],
+            'nodeName': 'structure',
+            'prerequisites': [],
+        },
         'quantity1': {
             'inputs': [],
-            'parsers': ['CONTCAR'],
             'nodeName': '',
             'is_alternative': 'quantity_with_alternatives',
             'prerequisites': []
@@ -127,9 +122,9 @@ def test_parsable_quantities(vasp_parser_with_test):
     for quantity in ExampleFileParser.PARSABLE_ITEMS:
         assert quantities.get_by_name(quantity) is not None
     # Check whether quantities have been set up correctly.
-    assert quantities.get_by_name('quantity1').has_files
+    assert not quantities.get_by_name('quantity1').missing_files
     assert quantities.get_by_name('quantity1').is_parsable
-    assert not quantities.get_by_name('quantity_with_alternatives').has_files
+    assert quantities.get_by_name('quantity_with_alternatives').missing_files
     assert quantities.get_by_name('quantity2').is_parsable
     assert not quantities.get_by_name('quantity3').is_parsable
     # check whether the additional non existing quantity has been added. This is for cases,


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

The 'parsers' card in the quantity definitions was a relict from the first rework of the `VaspParser` and it was intended to be used for setting the FileParsers that are required to parse a quantity. This has become obsolete/redundant in the current iteration of the VaspParser. 

Instead of using `parsers` to set the correct FileParsers for a quantity, now a quantity will have a `file_name` that is set dynamically based on the file name of the corresponding FileParser. 