### PR TITLE
fix links in README to point to the aiida-team repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,20 +2,20 @@
 AiiDA Vasp Plugin
 =================
 
-.. image:: https://travis-ci.org/DropD/aiida-vasp.svg?branch=develop
-    :target: https://travis-ci.org/DropD/aiida-vasp
+.. image:: https://travis-ci.org/aiida-team/aiida-vasp.svg?branch=develop
+    :target: https://travis-ci.org/aiida-team/aiida-vasp
 
 .. image:: https://readthedocs.org/projects/aiida-vasp/badge/?version=latest
    :target: http://aiida-vasp.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-.. image:: https://coveralls.io/repos/github/DropD/aiida-vasp/badge.svg?branch=coveralls
-   :target: https://coveralls.io/github/DropD/aiida-vasp?branch=coveralls
+.. image:: https://coveralls.io/repos/github/aiida-team/aiida-vasp/badge.svg?branch=coveralls
+   :target: https://coveralls.io/github/aiida-team/aiida-vasp?branch=coveralls
 
 This is a plugin to `AiiDA <www.aiida.net/?page_id=264>`_ to run calculations with the ab-initio program `VASP <https://www.vasp.at/>`_.
 
 * `Documentation <https://aiida-vasp.readthedocs.org/en/latest>`_
-* `Changelog <https://github.com/DropD/aiida-vasp/blob/develop/CHANGELOG.md>`_
+* `Changelog <https://github.com/aiida-team/aiida-vasp/blob/develop/CHANGELOG.md>`_
 
 Install and usage:
 ------------------


### PR DESCRIPTION
I, the author consider this PR
 - [X] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

fix: #200 

blocked by: #199 

## Description

Some links were pointing to the old location (DropD/aiida-vasp) of the repo. Those have been changed.