### PR TITLE
Fixed a bug with the ordering of the quantities in ExampleFileParser

### DIFF
--- a/aiida_vasp/parsers/quantity.py
+++ b/aiida_vasp/parsers/quantity.py
@@ -51,6 +51,7 @@ class ParsableQuantities(object):
 
     def __init__(self, vasp_parser=None):
         self._quantities = {}
+        self.additional_quantities = {}
 
         self._vasp_parser = vasp_parser
 
@@ -94,6 +95,11 @@ class ParsableQuantities(object):
         """Check uniqueness and add parsable quantities."""
 
         self._quantities = {}
+
+        # Add all the additional quantities that have been added by the user.
+        for key, value in self.additional_quantities.items():
+            self.add_parsable_quantity(key, value, retrieved)
+
         # Gather all parsable items as defined in the file parsers.
         for file_name, value in self._vasp_parser.settings.parser_definitions.items():
             for quantity, quantity_dict in value['parser_class'].PARSABLE_ITEMS.items():

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -52,11 +52,6 @@ class ExampleFileParser2(BaseFileParser):
     """Example class for testing non unique quantity identifiers."""
 
     PARSABLE_ITEMS = {
-        'quantity_with_alternatives': {
-            'inputs': [],
-            'nodeName': 'structure',
-            'prerequisites': [],
-        },
         'quantity1': {
             'inputs': [],
             'nodeName': '',
@@ -86,6 +81,15 @@ def vasp_parser_with_test(vasp_nscf_and_ref, ref_retrieved_nscf):
     vasp_calc.use_settings(ParameterData(dict={'parser_settings': {'add_quantity_with_alternatives': True, 'add_quantity2': True}}))
     parser = vasp_calc.get_parserclass()(vasp_calc)
     parser.add_file_parser('_scheduler-stdout.txt', {'parser_class': ExampleFileParser, 'is_critical': False})
+    parser.add_parsable_quantity(
+        'quantity_with_alternatives',
+        {
+            'file_name': 'DUMMY',
+            'inputs': [],
+            'nodeName': 'structure',
+            'prerequisites': [],
+        },
+    )
     success, outputs = parser.parse_with_retrieved({'retrieved': ref_retrieved_nscf})
     try:
         yield parser

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -98,16 +98,11 @@ def vasp_parser_with_test(vasp_nscf_and_ref, ref_retrieved_nscf):
 
 
 @ONLY_ONE_CALC
-def test_quantities_to_parse(vasp_nscf_and_ref, ref_retrieved_nscf):
+def test_quantities_to_parse(vasp_parser_with_test):
     """Check if quantities are added to quantities to parse correctly."""
     from aiida.orm.data.parameter import ParameterData
-    vasp_calc, _ = vasp_nscf_and_ref
-    vasp_calc.use_settings(ParameterData(dict={'parser_settings': {'add_quantity_with_alternatives': True, 'add_quantity2': True}}))
-    parser = vasp_calc.get_parserclass()(vasp_calc)
 
-    parser.add_file_parser('_scheduler-stdout.txt', {'parser_class': ExampleFileParser, 'is_critical': False})
-
-    parser.out_folder = parser.get_folder({'retrieved': ref_retrieved_nscf})
+    parser = vasp_parser_with_test
     parser.quantities.setup()
     parser.parsers.setup()
 

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -106,10 +106,9 @@ class VaspParser(BaseParser):
         self.settings.parser_definitions[parser_name] = parser_dict
         self.parsers.add_file_parser(parser_name, parser_dict)
 
-    def add_parsable_quantity(self, quantity_name, quantity_dict, retrieved_files=None):
+    def add_parsable_quantity(self, quantity_name, quantity_dict):
         """Add a single parsable quantity to the _parsable_quantities."""
-
-        self.quantities.add_parsable_quantity(quantity_name, quantity_dict, retrieved_files)
+        self.quantities.additional_quantities[quantity_name] = quantity_dict
 
     def parse_with_retrieved(self, retrieved):
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

(Potentially) fixes:

#199 

blocks:

#201 

is blocked by:

None of the above but is still related to the following:

## Description

The problem is that in `test_vasp_parser` the 'quantity3' `ExampleFileParser` lists `quantity_with_alternatives` as prerequisite. However `ExampleFileParser` does not define 'quantity_with_alternatives' itself. It will only be automatically generated when `quantity1` is processed before `quantity3`, because `quantity1` has `quantity_with_alternatives` as an alternative. And for undefined 'alternatives' dummy quantities will be generated